### PR TITLE
support regular expressions in opts.extensions

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -74,14 +74,15 @@ module.exports = (function () {
       if(group[4] == null) {
         result += group[1];
 
-        img = group[3].trim()
+        var rawUrl = group[3].trim();
+        img = rawUrl
           .replace(rQuotes, "")
           .replace(rParams, ""); // remove query string/hash parmams in the filename, like foo.png?bar or foo.png#bar
 
         if (opts.extensions) { //test for extensions if it provided
           var imgExt = img.split('.').pop();
           var test = opts.extensions.some(function (ext) {
-            return (ext instanceof RegExp) ? ext.test(img) : (ext === imgExt);
+            return (ext instanceof RegExp) ? ext.test(rawUrl) : (ext === imgExt);
           });
           if (!test) {
             if (opts.debug) {


### PR DESCRIPTION
I'd like to only inline certain images, and by adding support for RegExp in `opts.extensions` I'm able to name my image files `myimage--datauri.png`, and configure my gulp pipe like so:

```
.pipe( base64({
    baseDir: 'dist',
    extensions: [ (/--datauri\.(?:svg|png|gif|jpg)(?:$|\?)/) ]
  }) )
```
