### PR TITLE
fix(exclude): fix exclusion bug due to inverted conditional

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -87,13 +87,13 @@ module.exports = (function () {
           });
         }
         if (test && opts.exclude) { //test for extensions to exclude if it provided
-          test = opts.exclude.some(function (pattern) {
+          test = !opts.exclude.some(function (pattern) {
             return (pattern instanceof RegExp) ? pattern.test(rawUrl) : (rawUrl.indexOf(pattern) > -1);
           });
         }
         if (!test) {
           if (opts.debug) {
-            console.log(img + ' skipped by extensions filter');
+            console.log(img + ' skipped by extension or exclude filters');
           }
           result += group[2];
           return complete();


### PR DESCRIPTION
The `exclude` array was actually having the opposite effect as the conditional should have been inverted. The `some` test function returns true if any exclusion pattern was found, but while the test function should remain the same, we really want to negate that return value.