### PR TITLE
extensions and exclude can be functions

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -82,14 +82,22 @@ module.exports = (function () {
         var test = true;
         if (opts.extensions) { //test for extensions if it provided
           var imgExt = img.split('.').pop();
-          test = opts.extensions.some(function (ext) {
-            return (ext instanceof RegExp) ? ext.test(rawUrl) : (ext === imgExt);
-          });
+          if (typeof opts.extensions === 'function') {
+            test = opts.extensions(imgExt, rawUrl);
+          } else {
+            test = opts.extensions.some(function (ext) {
+              return (ext instanceof RegExp) ? ext.test(rawUrl) : (ext === imgExt);
+            });
+          }
         }
         if (test && opts.exclude) { //test for extensions to exclude if it provided
-          test = !opts.exclude.some(function (pattern) {
-            return (pattern instanceof RegExp) ? pattern.test(rawUrl) : (rawUrl.indexOf(pattern) > -1);
-          });
+          if (typeof opts.exclude === 'function') {
+            test = !opts.exclude(rawUrl);
+          } else {
+            test = !opts.exclude.some(function (pattern) {
+              return (pattern instanceof RegExp) ? pattern.test(rawUrl) : (rawUrl.indexOf(pattern) > -1);
+            });
+          }
         }
         if (!test) {
           if (opts.debug) {


### PR DESCRIPTION
Ran into a situation where we wanted to conditionally test image paths before encoding - figured it would be a useful feature for extensions as well as exclusions.