### PR TITLE
feat(line-length): add option to split output with newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ gulp.task('build', function () {
             extensions: ['svg', 'png', /\.jpg#datauri$/i],
             exclude:    [/\.server\.(com|net)\/dynamic\//, '--live.jpg'],
             maxImageSize: 8*1024, // bytes,
+            lineLength: 500,
             deleteAfterEncoding: false,
             debug: true
         }))
@@ -60,6 +61,9 @@ gulp.task('build', function () {
 
   - `maxImageSize` (Number)  
     Maximum filesize in bytes for changing image to base64.
+
+  - `lineLength` (Number)  
+    Line length to split output base64 with newlines.
 
   - `debug` (Boolean)  
     Enable log to console.

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -245,7 +245,7 @@ module.exports = (function () {
       // Read the file in and convert it.
       var src = fs.readFileSync(img);
       var type = mime.lookup(img);
-      var encoded = exports.getDataURI(type, src);
+      var encoded = exports.getDataURI(type, src, opts.lineLength);
       complete(null, encoded, true);
     }
   };
@@ -256,13 +256,22 @@ module.exports = (function () {
    *
    * @param mimeType Mime type of the image
    * @param img The source image
+   * @param lineLength Line length to split string with newlines
    * @return Data URI string
    */
-  exports.getDataURI = function(mimeType, img) {
-    var ret = "data:";
+  exports.getDataURI = function(mimeType, img, lineLength) {
+    var ret = "'data:";
     ret += mimeType;
     ret += ";base64,";
-    ret += img.toString("base64");
+    var b64 = img.toString("base64");
+    if (lineLength) {
+      var lineRegexp = new RegExp(".{1," + lineLength + "}", "g");
+      var lines = [""].concat(b64.match(lineRegexp));
+      ret += lines.join("\\\n");
+    } else {
+      ret += b64;
+    }
+    ret += "'";
     return ret;
   };
 


### PR DESCRIPTION
We ran into issue when our server wasn't able to process html file with embedded font because line length was too long. So I made a fork with option to specify line length for output base64. Maybe it'll be useful for someone else.
